### PR TITLE
Dev

### DIFF
--- a/JWT/jwt-signature-apis-challenges/app.js
+++ b/JWT/jwt-signature-apis-challenges/app.js
@@ -9,7 +9,7 @@ const { exec } = require('child_process');
 const app = express();
 app.use(express.json()); //midleware needed to handle post request
 
-//Environment: Disable unauthorized x509 certificates. 
+//Environment: Disable unauthorized x509 certificates.
 process.env["NODE_TLS_REJECT_UNAUTHORIZED"] = 0;
 
 //JWT payload
@@ -26,22 +26,22 @@ app.post('/jwt/none', (req, res) => { //None endpoint
     res.status(400).send('Send a HTTP request with a body with the format: {jwt: "< Place the JWT to test here >"}');
   } else {
     const jwt_b64_dec = JWT.decode(jwt_token, { complete: true });
-    if (jwt_b64_dec.header.alg == 'HS256') {
+    if (jwt_b64_dec.header.alg == 'none') {
+      res.status(400).send('It is required to sign the token.');
+    } else if (jwt_b64_dec.header.alg == 'HS256') {
       secret_key = '885ae2060fbedcfb491c5e8aafc92cab5a8057b3d4c39655acce9d4f09280a20';
-    } else if (jwt_b64_dec.header.alg == 'none') {
-      secret_key = '';
-    }
-    JWT.verify(jwt_token, secret_key, { algorithms: ['none', 'HS256'], complete: true, audience: 'https://127.0.0.1/jwt/none' }, (err, decoded_token) => {
-      if (err) {
-        res.status(400).json(err);
-      } else {
-        const success = {
-          message: 'Congrats!! You\'ve solved the JWT challenge!!',
-          jwt_token: decoded_token
+      JWT.verify(jwt_token, secret_key, { algorithms: ['HS256'], complete: true, audience: 'https://127.0.0.1/jwt/none' }, (err, decoded_token) => {
+        if (err) {
+          res.status(400).json(err);
+        } else {
+          const success = {
+            message: 'Congrats!! You\'ve solved the JWT challenge!!',
+            jwt_token: decoded_token
+          }
+          res.status(200).json(success);
         }
-        res.status(200).json(success);
-      }
-    });
+      });
+    }
   }
 });
 

--- a/Python/Flask_Book_Library/Dockerfile
+++ b/Python/Flask_Book_Library/Dockerfile
@@ -11,6 +11,8 @@ ENV PASSWORD=1qaz@WSX
 # Instalujemy zależności
 RUN pip install --no-cache-dir -r requirements.txt
 
+RUN python -m unittest discover -p "*test.py"
+
 # Ustawiamy zmienną środowiskową, aby Flask wiedział, jak uruchomić aplikację
 ENV FLASK_APP=app.py
 ENV FLASK_RUN_HOST=0.0.0.0

--- a/Python/Flask_Book_Library/project/tests/customers_test.py
+++ b/Python/Flask_Book_Library/project/tests/customers_test.py
@@ -1,0 +1,289 @@
+import unittest
+from itertools import product
+from project.customers.models import Customer
+
+# PESEL                   | Ciąg znaków składający się z 11 cyfr
+# Ulica                   | Ciąg [2-30] znaków składający się z liter i znaków {' ', '.', '-'}, może być pusty
+# Numer_mieszkania        | Ciąg znaków składający się z [1-3] cyfr, po cyfrach może znajdować się pojedyncza litera, może być pusty
+
+EXAMPLE_GOOD_ARGUMENTS = {
+    "name": "a" * 10,
+    "city": "a" * 10,
+    "age": 20,
+    "pesel": "0" * 11,
+    "street": "",
+    "appNo": "",
+}
+
+
+def swap_value_in_copy(base: dict, swapped_key: str, new_value):
+    new = base.copy()
+    new[swapped_key] = new_value
+    return new
+
+
+class TestCustomerCreation(unittest.TestCase):
+    def test_name_length(self):
+        with self.assertRaises(ValueError):
+            Customer(**swap_value_in_copy(EXAMPLE_GOOD_ARGUMENTS, "name", "a" * 2))
+        Customer(**swap_value_in_copy(EXAMPLE_GOOD_ARGUMENTS, "name", "a" * 3))
+        Customer(**swap_value_in_copy(EXAMPLE_GOOD_ARGUMENTS, "name", "a" * 40))
+        with self.assertRaises(ValueError):
+            Customer(**swap_value_in_copy(EXAMPLE_GOOD_ARGUMENTS, "name", "a" * 41))
+
+    def test_name_allowed_characters(self):
+        Customer(**swap_value_in_copy(EXAMPLE_GOOD_ARGUMENTS, "name", "amnz ZNMA"))
+
+    def test_name_forbidden_characters(self):
+        # fmt: off
+        for character in ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
+                          '!', '@', '#', '$', '%', '^', '&', '*', '(', ')',
+                          '-', '_', '=', '+', ',', '.', '/', '<', '>', '?',
+                          ';', '\'', '\\', ':', '\"', '|', '[', ']', '{', '}',
+                          '`', '~']:
+        # fmt:on
+            with self.assertRaises(ValueError):
+                Customer(**swap_value_in_copy(EXAMPLE_GOOD_ARGUMENTS, "name", character * 10))
+
+    def test_city_length(self):
+        with self.assertRaises(ValueError):
+            Customer(**swap_value_in_copy(EXAMPLE_GOOD_ARGUMENTS, "city", "a" * 2))
+        Customer(**swap_value_in_copy(EXAMPLE_GOOD_ARGUMENTS, "city", "a" * 3))
+        Customer(**swap_value_in_copy(EXAMPLE_GOOD_ARGUMENTS, "city", "a" * 30))
+        with self.assertRaises(ValueError):
+            Customer(**swap_value_in_copy(EXAMPLE_GOOD_ARGUMENTS, "city", "a" * 31))
+
+    def test_city_allowed_characters(self):
+        Customer(**swap_value_in_copy(EXAMPLE_GOOD_ARGUMENTS, "city", "amnz ZNMA"))
+
+    def test_city_forbidden_characters(self):
+        # fmt: off
+        for character in ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
+                          '!', '@', '#', '$', '%', '^', '&', '*', '(', ')',
+                          '_', '=', '+', '/', '<', '>', '?', ';', '\'', '\\',
+                          ':', '\"', '|', '[', ']', '{', '}', '`', '~']:
+        # fmt: on
+            with self.assertRaises(ValueError):
+                Customer(**swap_value_in_copy(EXAMPLE_GOOD_ARGUMENTS, "city", character * 10))
+
+    def test_age_not_string(self):
+        with self.assertRaises(TypeError):
+            Customer(**swap_value_in_copy(EXAMPLE_GOOD_ARGUMENTS, "age", "20"))
+
+    def test_age_edge_values(self):
+        with self.assertRaises(ValueError):
+            Customer(**swap_value_in_copy(EXAMPLE_GOOD_ARGUMENTS, "age", -1))
+        Customer(**swap_value_in_copy(EXAMPLE_GOOD_ARGUMENTS, "age", 0))
+        Customer(**swap_value_in_copy(EXAMPLE_GOOD_ARGUMENTS, "age", 122))
+        with self.assertRaises(ValueError):
+            Customer(**swap_value_in_copy(EXAMPLE_GOOD_ARGUMENTS, "age", 123))
+
+    def test_pesel_length(self):
+        with self.assertRaises(ValueError):
+            Customer(**swap_value_in_copy(EXAMPLE_GOOD_ARGUMENTS, "pesel", "0" * 10))
+        Customer(**swap_value_in_copy(EXAMPLE_GOOD_ARGUMENTS, "pesel", "0" * 11))
+        with self.assertRaises(ValueError):
+            Customer(**swap_value_in_copy(EXAMPLE_GOOD_ARGUMENTS, "pesel", "0" * 12))
+
+    def test_pesel_allowed_characters(self):
+        Customer(**swap_value_in_copy(EXAMPLE_GOOD_ARGUMENTS, "pesel", "12345678901"))
+
+    def test_pesel_forbidden_characters(self):
+        # fmt: off
+        alphabet = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p',
+                    'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z']
+        for character in alphabet + [letter.upper() for letter in alphabet] + [
+                         '!', '@', '#', '$', '%', '^', '&', '*', '(', ')',
+                         '_', '=', '+', '/', '<', '>', '?', ';', '\'', '\\',
+                         ':', '\"', '|', '[', ']', '{', '}', '`', '~']:
+        # fmt: on
+            with self.assertRaises(ValueError):
+                Customer(**swap_value_in_copy(EXAMPLE_GOOD_ARGUMENTS, "pesel", character * 11))
+
+    def test_street_length(self):
+        Customer(**swap_value_in_copy(EXAMPLE_GOOD_ARGUMENTS, "street", ""))
+        with self.assertRaises(ValueError):
+            Customer(**swap_value_in_copy(EXAMPLE_GOOD_ARGUMENTS, "street", "a"))
+        Customer(**swap_value_in_copy(EXAMPLE_GOOD_ARGUMENTS, "street", "a" * 2))
+        Customer(**swap_value_in_copy(EXAMPLE_GOOD_ARGUMENTS, "street", "a" * 30))
+        with self.assertRaises(ValueError):
+            Customer(**swap_value_in_copy(EXAMPLE_GOOD_ARGUMENTS, "street", "a" * 31))
+
+    def test_street_allowed_characters(self):
+        Customer(**swap_value_in_copy(EXAMPLE_GOOD_ARGUMENTS, "street", "am.nz ZN-MA"))
+
+    def test_street_forbidden_characters(self):
+        # fmt: off
+        for character in ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
+                          '!', '@', '#', '$', '%', '^', '&', '*', '(', ')',
+                          '_', '=', '+', ',',  '/', '<', '>', '?', ';', '\'',
+                          '\\', ':', '\"', '|', '[', ']', '{', '}', '`', '~']:
+        # fmt:on
+            with self.assertRaises(ValueError):
+                Customer(**swap_value_in_copy(EXAMPLE_GOOD_ARGUMENTS, "street", character * 10))
+
+    def test_appNo_length_no_letters(self):
+        Customer(**swap_value_in_copy(EXAMPLE_GOOD_ARGUMENTS, "appNo", ""))
+        Customer(**swap_value_in_copy(EXAMPLE_GOOD_ARGUMENTS, "appNo", "1"))
+        Customer(**swap_value_in_copy(EXAMPLE_GOOD_ARGUMENTS, "appNo", "111"))
+        with self.assertRaises(ValueError):
+            Customer(**swap_value_in_copy(EXAMPLE_GOOD_ARGUMENTS, "appNo", "1111"))
+
+    def test_appNo_length_with_letters(self):
+        Customer(**swap_value_in_copy(EXAMPLE_GOOD_ARGUMENTS, "appNo", "1a"))
+        Customer(**swap_value_in_copy(EXAMPLE_GOOD_ARGUMENTS, "appNo", "111a"))
+        with self.assertRaises(ValueError):
+            Customer(**swap_value_in_copy(EXAMPLE_GOOD_ARGUMENTS, "appNo", "1111a"))
+
+    def test_appNo_allowed_characters(self):
+        Customer(**swap_value_in_copy(EXAMPLE_GOOD_ARGUMENTS, "appNo", "159C"))
+
+    def test_appNo_forbidden_characters(self):
+        # fmt: off
+        for character in ['!', '@', '#', '$', '%', '^', '&', '*', '(', ')',
+                          '-', '_', '=', '+', ',', '.', '/', '<', '>', '?',
+                          ';', '\'', '\\', ':', '\"', '|', '[', ']', '{', '}',
+                          '`', '~']:
+        # fmt:on
+            with self.assertRaises(ValueError):
+                Customer(**swap_value_in_copy(EXAMPLE_GOOD_ARGUMENTS, "appNo", character * 2))
+
+    def test_appNo_letter_positioning(self):
+        for string in ["a", "a1", "1a1", "a1a", "1aa"]:
+            with self.assertRaises(ValueError):
+                Customer(**swap_value_in_copy(EXAMPLE_GOOD_ARGUMENTS, "appNo", string))
+
+
+class TestCustomerCreationExtremeData(unittest.TestCase):
+    def test_name(self):
+        for power in range(3, 11):
+            with self.assertRaises(ValueError):
+                Customer(**swap_value_in_copy(EXAMPLE_GOOD_ARGUMENTS, "name", "a" * 10**power))
+
+    def test_city(self):
+        for power in range(3, 11):
+            with self.assertRaises(ValueError):
+                Customer(**swap_value_in_copy(EXAMPLE_GOOD_ARGUMENTS, "city", "a" * 10**power))
+
+    def test_age(self):
+        for power in range(3, 11):
+            with self.assertRaises(ValueError):
+                Customer(**swap_value_in_copy(EXAMPLE_GOOD_ARGUMENTS, "age", 10**power))
+
+    def test_pesel(self):
+        for power in range(3, 11):
+            with self.assertRaises(ValueError):
+                Customer(**swap_value_in_copy(EXAMPLE_GOOD_ARGUMENTS, "pesel", "0" * 10**power))
+
+    def test_street(self):
+        for power in range(3, 11):
+            with self.assertRaises(ValueError):
+                Customer(**swap_value_in_copy(EXAMPLE_GOOD_ARGUMENTS, "street", "a" * 10**power))
+
+    def test_appNo(self):
+        for power in range(2, 11):
+            with self.assertRaises(ValueError):
+                Customer(**swap_value_in_copy(EXAMPLE_GOOD_ARGUMENTS, "appNo", "a" * 10**power))
+
+
+class TestCustomerCreationJavascriptInjections(unittest.TestCase):
+    def test_name(self):
+        with self.assertRaises(ValueError):
+            Customer(
+                **swap_value_in_copy(EXAMPLE_GOOD_ARGUMENTS, "name", "<script>alert(1)</script>")
+            )
+
+    def test_city(self):
+        with self.assertRaises(ValueError):
+            Customer(
+                **swap_value_in_copy(EXAMPLE_GOOD_ARGUMENTS, "city", "<script>alert(1)</script>")
+            )
+
+    def test_pesel(self):
+        with self.assertRaises(ValueError):
+            Customer(
+                **swap_value_in_copy(EXAMPLE_GOOD_ARGUMENTS, "pesel", "<script>alert(1)</script>")
+            )
+
+    def test_street(self):
+        with self.assertRaises(ValueError):
+            Customer(
+                **swap_value_in_copy(EXAMPLE_GOOD_ARGUMENTS, "street", "<script>alert(1)</script>")
+            )
+
+    def test_appNo(self):
+        with self.assertRaises(ValueError):
+            Customer(
+                **swap_value_in_copy(EXAMPLE_GOOD_ARGUMENTS, "appNo", "<script>alert(1)</script>")
+            )
+
+
+class TestCustomerCreationSQLInjections(unittest.TestCase):
+    SQL_TAUTOLOGIES = ["1=1", "TRUE", "1", "NONE IS NONE"]
+    COMMENT_OPENERS = ["#", "--", "/*"]
+
+    def test_name(self):
+        for tau in self.SQL_TAUTOLOGIES:
+            with self.assertRaises(ValueError):
+                Customer(**swap_value_in_copy(EXAMPLE_GOOD_ARGUMENTS, "name", f"' OR {tau}"))
+        for tau, com in product(self.SQL_TAUTOLOGIES, self.COMMENT_OPENERS):
+            with self.assertRaises(ValueError):
+                Customer(**swap_value_in_copy(EXAMPLE_GOOD_ARGUMENTS, "name", f"' OR {tau} {com} "))
+            with self.assertRaises(ValueError):
+                Customer(
+                    **swap_value_in_copy(EXAMPLE_GOOD_ARGUMENTS, "name", f"' OR {tau}) {com} ")
+                )
+
+    def test_city(self):
+        for tau in self.SQL_TAUTOLOGIES:
+            with self.assertRaises(ValueError):
+                Customer(**swap_value_in_copy(EXAMPLE_GOOD_ARGUMENTS, "city", f"' OR {tau}"))
+        for tau, com in product(self.SQL_TAUTOLOGIES, self.COMMENT_OPENERS):
+            with self.assertRaises(ValueError):
+                Customer(**swap_value_in_copy(EXAMPLE_GOOD_ARGUMENTS, "city", f"' OR {tau} {com} "))
+            with self.assertRaises(ValueError):
+                Customer(
+                    **swap_value_in_copy(EXAMPLE_GOOD_ARGUMENTS, "city", f"' OR {tau}) {com} ")
+                )
+
+    def test_pesel(self):
+        for tau in self.SQL_TAUTOLOGIES:
+            with self.assertRaises(ValueError):
+                Customer(**swap_value_in_copy(EXAMPLE_GOOD_ARGUMENTS, "pesel", f"' OR {tau}"))
+        for tau, com in product(self.SQL_TAUTOLOGIES, self.COMMENT_OPENERS):
+            with self.assertRaises(ValueError):
+                Customer(
+                    **swap_value_in_copy(EXAMPLE_GOOD_ARGUMENTS, "pesel", f"' OR {tau} {com} ")
+                )
+            with self.assertRaises(ValueError):
+                Customer(
+                    **swap_value_in_copy(EXAMPLE_GOOD_ARGUMENTS, "pesel", f"' OR {tau}) {com} ")
+                )
+
+    def test_street(self):
+        for tau in self.SQL_TAUTOLOGIES:
+            with self.assertRaises(ValueError):
+                Customer(**swap_value_in_copy(EXAMPLE_GOOD_ARGUMENTS, "street", f"' OR {tau}"))
+        for tau, com in product(self.SQL_TAUTOLOGIES, self.COMMENT_OPENERS):
+            with self.assertRaises(ValueError):
+                Customer(
+                    **swap_value_in_copy(EXAMPLE_GOOD_ARGUMENTS, "street", f"' OR {tau} {com} ")
+                )
+            with self.assertRaises(ValueError):
+                Customer(
+                    **swap_value_in_copy(EXAMPLE_GOOD_ARGUMENTS, "street", f"' OR {tau}) {com} ")
+                )
+
+    def test_appNo(self):
+        for tau in self.SQL_TAUTOLOGIES:
+            with self.assertRaises(ValueError):
+                Customer(**swap_value_in_copy(EXAMPLE_GOOD_ARGUMENTS, "appNo", f"' OR {tau}"))
+        for tau, com in product(self.SQL_TAUTOLOGIES, self.COMMENT_OPENERS):
+            with self.assertRaises(ValueError):
+                Customer(
+                    **swap_value_in_copy(EXAMPLE_GOOD_ARGUMENTS, "appNo", f"' OR {tau} {com} ")
+                )
+            with self.assertRaises(ValueError):
+                Customer(
+                    **swap_value_in_copy(EXAMPLE_GOOD_ARGUMENTS, "appNo", f"' OR {tau}) {com} ")
+                )


### PR DESCRIPTION
## Opis błędu
Aplikacja JWT przyjmowała niepodpisane tokeny pozwalając na ominięcie mechanizmu uwierzytelnienia i uzyskanie w ten sposób dostępu do konta administratora.

## Replikacja błędu
Nagłówek i zawartość tokenu uzyskanego z aplikacji (`eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhY2NvdW50IjoiQm9iIiwicm9sZSI6IlVzZXIiLCJpYXQiOjE3MDE5OTIyNjQsImF1ZCI6Imh0dHBzOi8vMTI3LjAuMC4xL2p3dC9ub25lIn0.Pz0Kz2C7CFHkd8r7hnnpQ0TvC-0ae3v8RImQQ9O7Rho`) zostały odkodowane z Base64 na zwykły tekst.
Wartość pola `"alg"` w nagłówku została zmieniona na `"none"`, a pola `"account"` w zawartości - na `"Administrator"`.
Zmienione pola zostały ponownie zakodowane na Base64 (uzyskano token: `eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0.eyJhY2NvdW50IjoiQWRtaW5pc3RyYXRvciIsInJvbGUiOiJVc2VyIiwiaWF0IjoxNzAxOTkyMjY0LCJhdWQiOiJodHRwczovLzEyNy4wLjAuMS9qd3Qvbm9uZSJ9`)
Na koniec nowego tokenu dopisano kropkę i wysłano zawierające go zapytanie.

## Odpowiedź serwera
![response](https://github.com/CzarekM2012/TBO_lab4/assets/93056774/e502e748-f448-4b52-930a-c98c10ccf5fc)

## Naprawa
Zmodyfikowano metodę zaczynającą się na linii `22` pliku `JWT/jwt-signature-apis-challanges/app.json`. Usunięta została ścieżka kodu, która kierowała niepodpisane tokeny do weryfikacji. Od teraz jeżeli aplikacja otrzyma token, którego pole `"alg"` jest równe `"none"` wysłana zostanie odpowiedź informująca o wymogu podpisania tokenu.

## Odpowiedź serwera po naprawie
Wysłano ten sam token co przed naprawą
![response-fixed](https://github.com/CzarekM2012/TBO_lab4/assets/93056774/b3554d2e-ee3e-45a1-9e58-5562c55f02f0)
